### PR TITLE
🐛 progressValueを依存配列に追加

### DIFF
--- a/src/components/TimerWithProgress.Tsx
+++ b/src/components/TimerWithProgress.Tsx
@@ -33,7 +33,7 @@ const TimerWithProgress: React.FC = () => {
 
   useEffect(() => {
     console.log("progress:", progressValue);
-  }, [timeLeft]); // timeLeftが変更された時のみログ出力
+  }, [timeLeft, progressValue]); // timeLeftが変更された時のみログ出力,progressValueを追加
 
   return (
     <div className="flex flex-col items-center">


### PR DESCRIPTION
useEffect内で使用しているprogressValueが依存配列に含まれていないため、ESLintから警告が出ていました。

progressValueを依存配列に追加しました。

progressValueが計算されるのは、timeLeftが変更されるときなので、timeLeftを依存配列に残し、progressValueを直接使用するようにします。これにより、依存関係の警告が解消されます。